### PR TITLE
feat: detect viewing photos as an active session

### DIFF
--- a/go-to-sleep.py
+++ b/go-to-sleep.py
@@ -106,6 +106,18 @@ def check_active_sessions():
         }
         active_sessions.append(session_info)
 
+    for track_node in tree.findall(".//Photo"):
+        user_node = track_node.find(".//User")
+        player_node = track_node.find(".//Player")
+
+        session_info = {
+            "user": user_node.get("title") if user_node is not None else "Unknown User",
+            "title": track_node.get("title"),
+            "type": "Photo",
+            "player_title": player_node.get("title") if player_node is not None else "Unknown Player",
+        }
+        active_sessions.append(session_info)
+
     return active_sessions
 
 def printSessionData(active_sessions):


### PR DESCRIPTION
### Notes
> Thanks for creating this Plex controller script which really helped with my situation of letting the PC go to sleep when not used after midnight (I can sleep happily now without hearing the fan noise of the PC)
- However, PC still went to sleep when I was actively viewing photos I added to my Plex server. This PR focuses on updating the script to resolve this issue.

### Changes
- Added support for detecting `viewing photos` (Photo) as an active session
- It's just an extension of `track_node` for loop of `Video` and `Track`

### Testing
- Copy and execute the `go-to-sleep.py` file
- Add some photos in the Plex server
- View the photos and see the photo title displayed in the logs

### Demo
> Tested locally on Windows 10 PC with `photos` media added to the Plex server

#### with active music and photos sessions
![plex_sleep_controller_logs](https://github.com/GoodDaveJ/plex-sleep-controller/assets/21148072/2fef829f-6a46-410e-b4b2-a6c83dd83298)

#### with active photos session
![plex_sleep_controller_log_active_photo_session](https://github.com/GoodDaveJ/plex-sleep-controller/assets/21148072/e237d050-41c6-48ff-8593-088adca7d8cc)
